### PR TITLE
Adding account alias to improve drop downs

### DIFF
--- a/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/sling/ConfigurationService.java
+++ b/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/sling/ConfigurationService.java
@@ -39,6 +39,7 @@ public interface ConfigurationService {
     public String getClientID();
     public String getClientSecret();
     public String getAccountID();
+    public String getAccountAlias();
     public List<String> getAllowedGroupsList();
     public String[] getAllowedGroups();
 }

--- a/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/sling/ConfigurationServiceImpl.java
+++ b/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/sling/ConfigurationServiceImpl.java
@@ -42,6 +42,7 @@ import java.util.*;
 		@Property(name="client_id", label="Client ID", description="CMS API Client ID", value=""),
 		@Property(name="client_secret", label="Client Secret", description="CMS API Client Secret", value=""),
 		@Property(name="key", label="Account ID", description="CMS API Account ID", value=""),
+		@Property(name="accountAlias", label="Account Alias", description="Text alias for Account ID", value=""),
 		@Property(name="readtoken", label="Read Token", description="Read Token", value=""),
 		@Property(name="writetoken", label="Write Token", description="Write Token", value=""),
     	@Property(name="playersstore", label="Players Store Path", description="Path of the players store locatione", value="/content/brightcovetools/players"),
@@ -115,6 +116,11 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 	public String getDefPlaylistPlayerKey() {
 		return (String) getProperties().get("defPlaylistPlayerKey");
 	}
+	
+	public String getAccountAlias() {
+		return (String) getProperties().get("accountAlias");
+	}
+	
     public String[] getAllowedGroups() {
         Object p =  getProperties().get("allowed_groups");
         if( p == null) return new String[0];

--- a/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/webservices/BrcAccounts.java
+++ b/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/webservices/BrcAccounts.java
@@ -95,9 +95,11 @@ public class BrcAccounts extends SlingAllMethodsServlet {
                         List<String> allowedGroups = new ArrayList<String>();
                         allowedGroups.addAll(cs.getAllowedGroupsList());
                         allowedGroups.retainAll(memberOf);
+                        String alias = cs.getAccountAlias();
+                        alias = (alias == null) ? account : alias;
                         if(allowedGroups.size()>0) {
                             JSONObject accountJson = new JSONObject();
-                            accountJson.put("text", account);
+                            accountJson.put("text", alias);
                             accountJson.put("value", account);
                             accountJson.put("id", i);
                             i++;


### PR DESCRIPTION
Adding ability to define an account with an alias to make the drop down selection easier for authors

![capture](https://cloud.githubusercontent.com/assets/915311/9260250/9116a682-41d4-11e5-988d-66bd1c528871.PNG)
