### PR TITLE
Allow for proxy server support

### DIFF
--- a/current/brightcove-services/src/main/java/com/brightcove/proserve/mediaapi/wrapper/ReadApi.java
+++ b/current/brightcove-services/src/main/java/com/brightcove/proserve/mediaapi/wrapper/ReadApi.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+
+import org.apache.http.conn.params.ConnRoutePNames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +63,8 @@ public class ReadApi {
     private Integer    readPort;
     private String     readPath;
     private HttpClient httpAgent;
-    
+    private String     proxy;
+
     private Boolean    enableUds;
     
     private static final String  READ_API_DEFAULT_SCHEME = "http";
@@ -145,6 +148,10 @@ public class ReadApi {
         log       = null;
         charSet   = "UTF-8";
         httpAgent = new DefaultHttpClient();
+        if (proxy!=null&&proxy.length()>0) {
+            httpAgent.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
+        }
+
         
         enableUds = false;
         
@@ -1382,5 +1389,13 @@ public class ReadApi {
      */
     public Boolean getEnableUds(){
         return enableUds;
+    }
+
+    public String getProxy() {
+        return proxy;
+    }
+
+    public void setProxy(String proxy) {
+        this.proxy = proxy;
     }
 }

--- a/current/brightcove-services/src/main/java/com/brightcove/proserve/mediaapi/wrapper/WriteApi.java
+++ b/current/brightcove-services/src/main/java/com/brightcove/proserve/mediaapi/wrapper/WriteApi.java
@@ -13,6 +13,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.apache.http.conn.params.ConnRoutePNames;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +67,7 @@ public class WriteApi {
 	private Integer    writePort;
 	private String     writePath;
 	private HttpClient httpAgent;
+    private String     proxy;
 	
 	private static final String  WRITE_API_DEFAULT_SCHEME = "http";
 	private static final String  WRITE_API_DEFAULT_HOST   = "api.brightcove.com";
@@ -137,8 +140,11 @@ public class WriteApi {
 		log       = null;
 		charSet   = "UTF-8";
 		httpAgent = new DefaultHttpClient();
-		
-		writeProtocolScheme = WRITE_API_DEFAULT_SCHEME;
+        if (proxy!=null&&proxy.length()>0) {
+            httpAgent.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
+        }
+
+        writeProtocolScheme = WRITE_API_DEFAULT_SCHEME;
 		writeHost           = WRITE_API_DEFAULT_HOST;
 		writePort           = WRITE_API_DEFAULT_PORT;
 		writePath           = WRITE_API_DEFAULT_PATH;
@@ -894,6 +900,14 @@ public class WriteApi {
 		
 		return response;
 	}
+
+    public String getProxy() {
+        return proxy;
+    }
+
+    public void setProxy(String proxy) {
+        this.proxy = proxy;
+    }
 }
 
 /**
@@ -941,5 +955,7 @@ class GenerateFileData {
 		}
 		return result;
 	}
+
+
 }
 

--- a/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/BrightcoveAPI.java
+++ b/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/BrightcoveAPI.java
@@ -16,13 +16,6 @@ public class BrightcoveAPI {
         platform = new Platform();
         account = new Account(platform, aClient_id, aClient_secret, aAccount_id);
         cms = new Cms(account);
-
-        ConfigurationGrabber cg = ServiceUtil.getConfigurationGrabber();
-        ConfigurationService brcService = cg.getConfigurationService(key);
-
-        if (brcService.getProxy()!=null && brcService.getProxy().length()>0) {
-            platform.setProxy(brcService.getProxy());
-        }
     }
 
     public BrightcoveAPI(String key) {

--- a/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/BrightcoveAPI.java
+++ b/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/BrightcoveAPI.java
@@ -22,6 +22,10 @@ public class BrightcoveAPI {
         platform = new Platform();
         ConfigurationGrabber cg = ServiceUtil.getConfigurationGrabber();
         ConfigurationService brcService = cg.getConfigurationService(key);
+
+        if (brcService.getProxy()!=null && brcService.getProxy().length()>0) {
+            platform.setProxy(brcService.getProxy());
+        }
         account = new Account(platform, brcService.getClientID(), brcService.getClientSecret(), brcService.getAccountID());
         cms = new Cms(account);
     }

--- a/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/BrightcoveAPI.java
+++ b/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/BrightcoveAPI.java
@@ -16,6 +16,13 @@ public class BrightcoveAPI {
         platform = new Platform();
         account = new Account(platform, aClient_id, aClient_secret, aAccount_id);
         cms = new Cms(account);
+
+        ConfigurationGrabber cg = ServiceUtil.getConfigurationGrabber();
+        ConfigurationService brcService = cg.getConfigurationService(key);
+
+        if (brcService.getProxy()!=null && brcService.getProxy().length()>0) {
+            platform.setProxy(brcService.getProxy());
+        }
     }
 
     public BrightcoveAPI(String key) {
@@ -24,9 +31,13 @@ public class BrightcoveAPI {
         ConfigurationService brcService = cg.getConfigurationService(key);
 
         if (brcService.getProxy()!=null && brcService.getProxy().length()>0) {
-            platform.setProxy(brcService.getProxy());
+            setProxy(brcService.getProxy());
         }
         account = new Account(platform, brcService.getClientID(), brcService.getClientSecret(), brcService.getAccountID());
         cms = new Cms(account);
+    }
+
+    public void setProxy(String proxy) {
+        platform.setProxy(proxy);
     }
 }

--- a/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/objects/Platform.java
+++ b/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/objects/Platform.java
@@ -1,7 +1,8 @@
 package com.coresecure.brightcove.wrapper.objects;
 
 import com.coresecure.brightcove.wrapper.utils.HttpServices;
-
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.util.Map;
 
 public class Platform {
@@ -13,10 +14,12 @@ public class Platform {
     private static String PLAYERS_API_Url;
     private static String API_Url;
     private static String DI_API_Url;
+    private static Proxy PROXY = Proxy.NO_PROXY;
 
     public Platform() {
 
     }
+
 
     public Platform(String aOAUTH_Url, String aAPI_Url, String aDI_API_Url, String aPLAYERS_API_Url) {
         OAUTH_Url = aOAUTH_Url;
@@ -84,5 +87,19 @@ public class Platform {
         String response = HttpServices.excuteDelete(URL, headers);
         System.out.println(response);
         return response;
+    }
+
+
+    public void setProxy(String proxy) {
+      Proxy newProxy = Proxy.NO_PROXY;
+
+      if(proxy!=null) {
+        String[] parts = proxy.split(":");
+        if (parts.length==2) {
+          PROXY = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(parts[0], Integer.parseInt(parts[1])));
+        }
+      }
+
+      HttpServices.setProxy(PROXY);
     }
 }

--- a/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/sling/ConfigurationService.java
+++ b/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/sling/ConfigurationService.java
@@ -56,4 +56,6 @@ public interface ConfigurationService {
     List<String> getAllowedGroupsList();
 
     String[] getAllowedGroups();
+
+    String getProxy();
 }

--- a/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/sling/ConfigurationServiceImpl.java
+++ b/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/sling/ConfigurationServiceImpl.java
@@ -52,7 +52,8 @@ import java.util.*;
         @Property(name = "defPlaylistPlayerKey", label = "Default Playlist Player Key", description = "Default Playlist Player Key", value = ""),
         @Property(name = "previewPlayerLoc", label = "Preview Video Player", description = "Preview Player Path (Videos)", value = "http://link.brightcove.com/services/player/bcpid1154829530001"),
         @Property(name = "previewPlayerListLoc", label = "Preview Playlist Player", description = "Preview Player Path (Playlists)", value = "http://link.brightcove.com/services/player/bcpid1154829529001"),
-        @Property(name = "allowed_groups", label = "Allowed Groups", description = "Groups that are allowed to see this account data", value = {"administrators", ""})
+        @Property(name = "allowed_groups", label = "Allowed Groups", description = "Groups that are allowed to see this account data", value = {"administrators", ""}),
+        @Property(name = "proxy", label = "Proxy server", description = "Proxy server in the form proxy.foo.com:3128", value = {""})
 })
 
 
@@ -141,6 +142,11 @@ public class ConfigurationServiceImpl implements ConfigurationService {
 
     public List<String> getAllowedGroupsList() {
         return Arrays.asList(getAllowedGroups());
+    }
+
+
+    public String getProxy() {
+        return (String) getProperties().get("proxy");
     }
 
     private String[] cleanStringArray(String[] input) {

--- a/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/utils/HttpServices.java
+++ b/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/utils/HttpServices.java
@@ -5,10 +5,21 @@ import java.io.DataOutputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.Proxy;
 import java.net.URL;
 import java.util.Map;
 
 public class HttpServices {
+    private static Proxy PROXY = Proxy.NO_PROXY;
+
+    public static void setProxy(Proxy proxy) {
+        if (proxy==null) {
+            PROXY = Proxy.NO_PROXY;
+        } else {
+            PROXY = proxy;
+        }
+    }
+
     public static String excuteDelete(String targetURL, Map<String, String> headers) {
         URL url;
         HttpURLConnection connection = null;
@@ -16,7 +27,7 @@ public class HttpServices {
         try {
             //Create connection
             url = new URL(targetURL);
-            connection = (HttpURLConnection) url.openConnection();
+            connection = (HttpURLConnection) url.openConnection(PROXY);
             connection.setRequestMethod("DELETE");
             connection.setRequestProperty("Content-Type", "application/json");
             connection.setRequestProperty("Content-Length", "" + Integer.toString(payload.getBytes().length));
@@ -65,7 +76,7 @@ public class HttpServices {
         try {
             //Create connection
             url = new URL(targetURL);
-            connection = (HttpURLConnection) url.openConnection();
+            connection = (HttpURLConnection) url.openConnection(PROXY);
             connection.setRequestMethod("POST");
             connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
             connection.setRequestProperty("Content-Length", "" + Integer.toString(payload.getBytes().length));
@@ -113,7 +124,7 @@ public class HttpServices {
         try {
             //Create connection
             url = new URL(targetURL + "?" + urlParameters);
-            connection = (HttpURLConnection) url.openConnection();
+            connection = (HttpURLConnection) url.openConnection(PROXY);
             connection.setRequestMethod("GET");
             connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
             connection.setRequestProperty("Content-Length", "" + Integer.toString(urlParameters.getBytes().length));

--- a/current/brightcove-view/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/proxy.POST.jsp
+++ b/current/brightcove-view/src/main/content/jcr_root/apps/brightcove/components/tools/brightcoveadmin/proxy.POST.jsp
@@ -54,6 +54,10 @@
     ConfigurationService cs = cg.getConfigurationService(selectedAccount);
     com.coresecure.brightcove.wrapper.BrightcoveAPI brAPI = new com.coresecure.brightcove.wrapper.BrightcoveAPI(cs.getClientID(), cs.getClientSecret(), selectedAccount);
 
+    if (cs.getProxy()!=null && cs.getProxy().length()>0) {
+      brAPI.setProxy(cs.getProxy());
+    }
+
     String ReadToken = cs.getReadToken();
     String WriteToken = cs.getWriteToken();
     response.reset();
@@ -71,6 +75,11 @@
     response.setContentType("text/html");
     WriteApi wapi = new WriteApi(logger);
     ReadApi rapi = new ReadApi(logger);
+    if (cs.getProxy()!=null && cs.getProxy().length()>0) {
+      wapi.setProxy(cs.getProxy());
+      rapi.setProxy(cs.getProxy());
+    }
+
     boolean success = false;
     JSONObject root = new JSONObject();
     String msg = "";


### PR DESCRIPTION
Handle the use case where the Aem (author/publisher) are behind a firewall and the firewall cant be opened. But they can talk to the internets via a proxy server. 

This allows this component to use a proxy server.