### PR TITLE
Set byte array, reader, and response to use UTF-8 encoding

### DIFF
--- a/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/utils/HttpServices.java
+++ b/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/utils/HttpServices.java
@@ -30,7 +30,7 @@ public class HttpServices {
             connection = (HttpURLConnection) url.openConnection(PROXY);
             connection.setRequestMethod("DELETE");
             connection.setRequestProperty("Content-Type", "application/json");
-            connection.setRequestProperty("Content-Length", "" + Integer.toString(payload.getBytes().length));
+            connection.setRequestProperty("Content-Length", "" + Integer.toString(payload.getBytes("UTF-8").length));
             connection.setRequestProperty("Content-Language", "en-US");
             for (String key : headers.keySet()) {
                 connection.setRequestProperty(key, headers.get(key));
@@ -47,7 +47,7 @@ public class HttpServices {
 
             //Get Response
             InputStream is = connection.getInputStream();
-            BufferedReader rd = new BufferedReader(new InputStreamReader(is));
+            BufferedReader rd = new BufferedReader(new InputStreamReader(is, "UTF-8"));
             String line;
             StringBuffer response = new StringBuffer();
             while ((line = rd.readLine()) != null) {

--- a/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/webservices/BrcApi.java
+++ b/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/webservices/BrcApi.java
@@ -83,8 +83,8 @@ public class BrcApi extends SlingAllMethodsServlet {
     public void api(final SlingHttpServletRequest request,
                     final SlingHttpServletResponse response) throws ServletException,
             IOException {
+        response.setContentType("application/json;charset=UTF-8");
         PrintWriter outWriter = response.getWriter();
-        response.setContentType("application/json");
 
         int requestedAPI = 0;
         String requestedAccount = "";


### PR DESCRIPTION
Set encoding to UTF-8 in order to properly display special characters in movie titles and descriptions when being delivered as JSON from the API