### PR TITLE
move misplaced UTF-8 encoding - was meant for excutePost and excuteGet

### DIFF
--- a/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/utils/HttpServices.java
+++ b/current/brightcove-services/src/main/java/com/coresecure/brightcove/wrapper/utils/HttpServices.java
@@ -30,7 +30,7 @@ public class HttpServices {
             connection = (HttpURLConnection) url.openConnection(PROXY);
             connection.setRequestMethod("DELETE");
             connection.setRequestProperty("Content-Type", "application/json");
-            connection.setRequestProperty("Content-Length", "" + Integer.toString(payload.getBytes("UTF-8").length));
+            connection.setRequestProperty("Content-Length", "" + Integer.toString(payload.getBytes().length));
             connection.setRequestProperty("Content-Language", "en-US");
             for (String key : headers.keySet()) {
                 connection.setRequestProperty(key, headers.get(key));
@@ -47,7 +47,7 @@ public class HttpServices {
 
             //Get Response
             InputStream is = connection.getInputStream();
-            BufferedReader rd = new BufferedReader(new InputStreamReader(is, "UTF-8"));
+            BufferedReader rd = new BufferedReader(new InputStreamReader(is));
             String line;
             StringBuffer response = new StringBuffer();
             while ((line = rd.readLine()) != null) {
@@ -79,7 +79,7 @@ public class HttpServices {
             connection = (HttpURLConnection) url.openConnection(PROXY);
             connection.setRequestMethod("POST");
             connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
-            connection.setRequestProperty("Content-Length", "" + Integer.toString(payload.getBytes().length));
+            connection.setRequestProperty("Content-Length", "" + Integer.toString(payload.getBytes("UTF-8").length));
             connection.setRequestProperty("Content-Language", "en-US");
             for (String key : headers.keySet()) {
                 connection.setRequestProperty(key, headers.get(key));
@@ -96,7 +96,7 @@ public class HttpServices {
 
             //Get Response
             InputStream is = connection.getInputStream();
-            BufferedReader rd = new BufferedReader(new InputStreamReader(is));
+            BufferedReader rd = new BufferedReader(new InputStreamReader(is, "UTF-8"));
             String line;
             StringBuffer response = new StringBuffer();
             while ((line = rd.readLine()) != null) {
@@ -127,7 +127,7 @@ public class HttpServices {
             connection = (HttpURLConnection) url.openConnection(PROXY);
             connection.setRequestMethod("GET");
             connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
-            connection.setRequestProperty("Content-Length", "" + Integer.toString(urlParameters.getBytes().length));
+            connection.setRequestProperty("Content-Length", "" + Integer.toString(urlParameters.getBytes("UTF-8").length));
             connection.setRequestProperty("Content-Language", "en-US");
             for (String key : headers.keySet()) {
                 connection.setRequestProperty(key, headers.get(key));
@@ -138,7 +138,7 @@ public class HttpServices {
             connection.connect();
             //Get Response
             InputStream is = connection.getInputStream();
-            BufferedReader rd = new BufferedReader(new InputStreamReader(is));
+            BufferedReader rd = new BufferedReader(new InputStreamReader(is, "UTF-8"));
             String line;
             StringBuffer response = new StringBuffer();
             while ((line = rd.readLine()) != null) {


### PR DESCRIPTION
Accidentally specified UTF-8 encoding in the excuteDelete method. Removed this and added to excutePost and excuteGet